### PR TITLE
Support SignalR hubs at https

### DIFF
--- a/WhitedUS.SignalR/WhitedUS.signalR/signalR.js
+++ b/WhitedUS.SignalR/WhitedUS.signalR/signalR.js
@@ -157,7 +157,7 @@ function negotiateProxies(baseUrl, hubNames, onSuccess, onError, _client) {
     
     if (negotiateUrlOptions.protocol === 'http:') {
         var negotiateResult = http.get(negotiateUrlOptions, negotiateFunction).on('error', negotiateErrorFunction);
-    } else if (negotiateUrlOptions.protocol === 'wss:') {
+    } else if (negotiateUrlOptions.protocol === 'wss:' || negotiateUrlOptions.protocol === 'https:') {
         negotiateUrlOptions.protocol = 'https:';
         var negotiateResult = https.get(negotiateUrlOptions, negotiateFunction).on('error', negotiateErrorFunction);
     } else {


### PR DESCRIPTION
I'm using signalr-client to connect to a hub running under https. With the version 0.0.13 I can't accomplish that. 
I've done some changes to do that.