### PR TITLE
Include custom data in negotiation query string

### DIFF
--- a/WhitedUS.SignalR/WhitedUS.signalR/signalR.js
+++ b/WhitedUS.SignalR/WhitedUS.signalR/signalR.js
@@ -84,10 +84,19 @@ function negotiateProxies(baseUrl, hubNames, onSuccess, onError, _client) {
     }
 
     var negotiateData = "";
-    var negotiateUrl = baseUrl + "/negotiate?" + querystring.stringify({
-        connectionData: JSON.stringify(cleanedHubs),
-        clientProtocol: 1.5
-    });
+    var queryData = {
+      connectionData: JSON.stringify(cleanedHubs),
+      clientProtocol: 1.5
+    };
+
+    if (_client.queryString) {
+        for (var propName in _client.queryString) {
+            queryData[propName] = _client.queryString[propName];
+        }
+    }
+
+    var negotiateUrl = baseUrl + "/negotiate?" + querystring.stringify(queryData);
+
     var negotiateUrlOptions = url.parse(negotiateUrl, true);
 
     var negotiateFunction = function (res) {
@@ -435,7 +444,7 @@ function clientInterface(baseUrl, hubs, reconnectTimeout, doNotStart) {
 		var cb = callCallbacks[messageId];
 		if (cb) cb(err, result);
 	}
-	
+
     client.start = function () {
         _client.getBinding();
     };


### PR DESCRIPTION
Previously the query-string wasn't used for the negotiation call.

This is necessary for authorization via query-string.