### PR TITLE
Modified negotiation error handling

### DIFF
--- a/WhitedUS.SignalR/WhitedUS.signalR/signalR.js
+++ b/WhitedUS.SignalR/WhitedUS.signalR/signalR.js
@@ -104,10 +104,10 @@ function negotiateProxies(baseUrl, hubNames, onSuccess, onError, _client) {
                     if (_client.serviceHandlers.onUnauthorized) {
                         _client.serviceHandlers.onUnauthorized(res);
                     } else {
-                        console.log('negotiate::Unauthorized (' + res.statusCode + ')');
+                        onError('Negotiate Unauthorized', undefined, res.statusCode);
                     }
                 } else {
-                    console.log('negotiate::unknown (' + res.statusCode + ')');
+                    onError('Negotiate Unknown', undefined, res.statusCode);
                 }
             } catch (e) {
                 onError('Parse Error', e, negotiateData);
@@ -778,7 +778,7 @@ function clientInterface(baseUrl, hubs, reconnectTimeout, doNotStart) {
             }
 
             _client.start(true);
-        }, handlerErrors, _client);
+        }, (_client.serviceHandlers.onerror ? client.serviceHandlers.onerror : handlerErrors), _client);
     };
 
     if (doNotStart) {


### PR DESCRIPTION
When the client encountered a 404 or 401 / 302 status code it would only console.log the error rather than providing any callback.  I modified these two functions to follow the style throughout other functions.

I also modified the onError callback to call onerror service handler if defined then failback to handlerError.