### PR TITLE
onerror fix

### DIFF
--- a/WhitedUS.SignalR/WhitedUS.signalR/signalR.js
+++ b/WhitedUS.SignalR/WhitedUS.signalR/signalR.js
@@ -778,7 +778,13 @@ function clientInterface(baseUrl, hubs, reconnectTimeout, doNotStart) {
             }
 
             _client.start(true);
-        }, (_client.serviceHandlers.onerror ? client.serviceHandlers.onerror : handlerErrors), _client);
+        }, function(errorMessage, exception, errorData) {
+            if (_client.serviceHandlers.onerror) {
+                _client.serviceHandlers.onerror(errorMessage, exception, errorData);
+            } else {
+                handlerErrors(errorMessage, exception, errorData);
+            }
+        }, _client);
     };
 
     if (doNotStart) {


### PR DESCRIPTION
the case of bindingError in getBindings() always returned handlerErrors() instead of the user-defined serviceHandlers.onerror() method.