### PR TITLE
Update to use new websocket version

### DIFF
--- a/WhitedUS.SignalR/WhitedUS.signalR/package.json
+++ b/WhitedUS.SignalR/WhitedUS.signalR/package.json
@@ -15,7 +15,7 @@
         "url": "https://www.linkedin.com/in/mwwhited"
     },
     "dependencies": {
-        "websocket": "^1.0.17"
+        "websocket": "^1.0.26"
     },
     "engines": {
         "node": "*"


### PR DESCRIPTION
Updated websocket package dependency from "^1.0.17" to latest (1.0.26).

On node 10.x, the old websocket package gives the following error:

Error Message:  Parse Error
Exception:  RangeError [ERR_OUT_OF_RANGE]: The value of "value" is out of range. It must be >= 0 and <= 4294967295. Received -1856715192

The same issue was seen by others, which was then later resolved:
https://github.com/ethereum/web3.js/issues/1613
https://github.com/theturtle32/WebSocket-Node/commit/12ed73d77c1762e24ae1ad6b206d1671e3c0fd5a