### PR TITLE
Add getter for signalr connection

### DIFF
--- a/WhitedUS.SignalR/WhitedUS.signalR/signalR.js
+++ b/WhitedUS.SignalR/WhitedUS.signalR/signalR.js
@@ -342,6 +342,8 @@ function clientInterface(baseUrl, hubs, reconnectTimeout, doNotStart) {
         return result;
     });
 
+    client.__defineGetter__('connection', function () { return _client.connection; });
+
     client.__defineGetter__('handlers', function () { return _client.handlers; });
     client.__defineSetter__('handlers', function (val) { mergeFrom(_client.handlers, val); });
 


### PR DESCRIPTION
This is the fix for my recently opened issue #27.

I just added a getter for `connection` to the client.