### PR TITLE
Add .off() method on client to remove method listeners

### DIFF
--- a/WhitedUS.SignalR/WhitedUS.signalR/signalR.js
+++ b/WhitedUS.SignalR/WhitedUS.signalR/signalR.js
@@ -385,6 +385,12 @@ function clientInterface(baseUrl, hubs, reconnectTimeout, doNotStart) {
         }
         var method = handler[methodName.toLowerCase()] = callback;
     };
+    client.off = function (hubName, methodName) {
+        var handler = _client.handlers[hubName.toLowerCase()];
+        if (handler) {
+            delete handler[methodName.toLowerCase()];
+        }
+    };
     client.end = function () {
         if ((_client.connection.state == states.connection.connecting
             || _client.connection.state == states.connection.connected)


### PR DESCRIPTION
Allows the client to remove a specific listener from the hub.
Usage:
```javascript
client.on('TestHub', 'somemethod', () => {..})

client.off('TestHub', 'somemethod')
```